### PR TITLE
added pcm_s24le decoder

### DIFF
--- a/lib/pkg/ffmpeg.sh
+++ b/lib/pkg/ffmpeg.sh
@@ -13,6 +13,7 @@ mjpeg
 mp2float
 mp3float
 pcm_s16le
+pcm_s24le
 srt
 vorbis
 "


### PR DESCRIPTION
added missing pcm decoder, was erroneous removed 08/08/2015
